### PR TITLE
Fulfill #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@ NodeJS-based modular website monitoring application
 
 ## Background
 This project was created out of a need for a simple, solid website monitoring solution while network maintenance took place at my job. Following the maintenance, the utility of having a custom-written monitoring package that performs exactly the way we want/need it became pretty obvious.
+
+## Setup
+### Packages
+The following 3rd party packages are required from NPM:
+* colors
+* dateformat
+* performance-now
+* jsonschema

--- a/app.js
+++ b/app.js
@@ -343,3 +343,14 @@ function ProcessTestResponse(test, response) {
 	else
 		logger.warn(`Test ${test.friendlyName} completed with overall result of ${overallTestResult}`);
 }
+
+function logResult(consoleData, fileData) {
+	if (fileData === undefined)
+		fileData = consoleData;
+
+	// Log to console
+	console.log(`[${dateFormat(new Date(), "HH:MM:ss")}]: ${consoleData}`);
+
+	// Log to file
+	fs.appendFileSync("./log.txt", `[${dateFormat(new Date(), "HH:MM:ss")}]: ${fileData}\n`);
+}

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ var colors = require("colors");
 var dateFormat = require("dateformat");
 var fs = require("fs");
 var now = require("performance-now");
-var async = require("async");
+var winston = require("winston");
 var testFunctions = require("./tests.js");
 var Validator = require('jsonschema').Validator;
 var v = new Validator();
@@ -15,89 +15,102 @@ var configuration;
 var tests = [];
 
 function LoadConfigurationData(configFilename) {
-	console.log("Loading configuration file " + configFilename);
+	logger.info(`Configuration file is ${configFilename}`);
+	logger.silly(`Attempting to load configuration data from file ${configFilename}`);
 
-	// Load the configuration file
+	// Check that the specified configuration file exists
 	if (!fs.existsSync(configFilename))
 	{
-		// Configuration file does not exist
-		console.log("FATAL".red + ": Configuration file config.js does not exist, exiting.");
+		logger.error(`Configuration file ${configFilename} does not exist, terminating.`);;
 		process.exit(1);
 	}
 	else {
-		// Read the config file and parse as JSON
+		// Read the contents of the configuration file
 		try {
 			var configData = fs.readFileSync(configFilename, "utf-8");
 		}
 		catch (err) {
-			console.log("FATAL".red + `: Error reading configuration file config.js:\n${err}`);
+			// We got an error of some sort reading the file, bail out
+			logger.error(`Error reading contents of configuration file ${configFilename}, exiting.`, err);
 			process.exit(1);
 		}
 
 		// Test file length
 		if (configData.length === 0)
 		{
-			console.log("FATAL".red + ": No configuration data found in file config.js, exiting.");
+			// The configuration file contains no data
+			logger.error(`Configuration file ${configFilename} contains no data, exiting.`);
 			process.exit(1);
 		}
 		else {
-			// Parse the configuration data
+			// Attempt to parse the configuration data
 			try {
 				return JSON.parse(configData);
 			}
 			catch (err) {
-				console.log("FATAL".red + `: Error parsing configuration data:\n${err}`);
+				// Error parsing the configuration data as JSON
+				logger.error(`Error parsing configuration file ${configFilename} as JSON, exiting.`, err);
 				process.exit(1);
 			}
 		}
 	}
+
+	logger.silly(`Configuration data loaded from file ${configFilename}`);
 }
 
 function ValidateConfigurationData(config) {
-	console.log("Validating " + JSON.stringify(config).length + " bytes of configuration data from " + configFilename);
+	logger.silly(`Validating ${JSON.stringify(config).length} bytes of configuration data.`);
 
 	// Configuration must contain a version as a top-level key, otherwise we don't know what to validate against
 	if (!config.hasOwnProperty("version"))
 	{
-		console.log("FATAL".red + ": Configuration file missing 'version' key, cannot validate. Exiting.");
+		logger.error("Configuration object missing \"version\" key, cannot validate. Exiting.");
 		process.exit(1);
 	}
 	else
 	{
+		// Determine the config object version
 		switch (config.version) {
 			case 1:
-				console.log("Validating configuration file version 1");
+				logger.debug("Configuration object is version 1.");
+				logger.silly("Validating configuration object against version 1 schema.");
 
 				// Validate the configuration data against the schema
 				var result = v.validate(config, configSchema);
 
 				if (result.valid)
+				{
+					logger.silly("Configuration object passes validation.");
 					return true;
+				}
 				else
 				{
-					console.log("FATAL".red + ": Configuration data is invalid, exiting.");
+					logger.error("Configuration object failed schema validation, exiting.");
 					process.exit(1);
 				}
 				break;
 			default:
-				console.log("FATAL".red + `: Unknown configuration version number ${config.version} found in config file.`);
+				// Unexpected version number found in file
+				logger.error(`Configuration object identifies itself as version ${config.version}, an unknown version.`);
 				break;
 		}
 	}
 }
 
+// Processes the incoming commandline arguments and acts on the values passed
 function ParseCommandLine(argv) {
-	console.log("Parsing " + (argv.length - 2) / 2 + " command line switches");
+	logger.info(`Execution commandline: ${argv.join(" ")}`);
+	logger.debug("Parsing " + ((argv.length - 2) / 2).toFixed(0) + " command line switches");
 
 	for(i = 2;i<argv.length;i++)
 	{
 		switch(argv[i].toLowerCase()) {
 			case "--config":
-				console.log("Overriding default configuration filename with passed value " + argv[i+1].toLowerCase());
+				logger.debug(`Overriding default configuration filename with passed value ${argv[i+1].toLowerCase()}`);
 				configFilename = argv[i+1].toLowerCase();
 				break;
 			default:
-				console.log("Unknown command-line parameter passed: " + argv[i].toLowerCase());
+				logger.warn(`Unknown command-line parameter passed: ${argv[i].toLowerCase()}`);
 				break;
 		}
 
@@ -105,21 +118,24 @@ function ParseCommandLine(argv) {
 	}
 }
 
+// Object prototype for holding responses from remote servers
 function WebResponse() {
 	this.responseCode = 0;
 	this.responseData = "";
 	this.responseTime = 0;
 }
 
+// Object prototype for holding test configuration
 function Test(testFromConfig, idx) {
 	this.idx = idx;
 	this.name = testFromConfig.name;
 	this.friendlyName = testFromConfig.friendlyName;
 	this.url = testFromConfig.url;
+	// Polling interval is stored in seconds in the configuration, convert to milliseconds.
 	this.pollingInterval = testFromConfig.pollingInterval * 1000;
 	this.successCondition = testFromConfig.successCondition;
 	this.ExecuteTest = () => {
-		console.log(`Executing test ${this.friendlyName} with url ${this.url}`);
+		logger.info(`[${this.idx}] Executing test ${this.friendlyName}`);
 
 		var result = RequestUrl(this, ProcessTestResponse);
 	};
@@ -128,6 +144,8 @@ function Test(testFromConfig, idx) {
 function SetConfiguration(config, callback) {
 	var idx = 0;
 
+	logger.silly("Setting configuration variables from configuration object");
+
 	// Store the configuration in a global var for use elsewhere
 	configuration = config;
 
@@ -135,10 +153,13 @@ function SetConfiguration(config, callback) {
 	config.tests.forEach((value) => {
 		idx++;
 
-		console.log("Setting up test " + value.friendlyName);
+		logger.debug("Configuring test " + value.friendlyName);
 
 		tests.push(new Test(value, idx));
 	});
+
+	logger.debug(`${tests.length} tests configured.`);
+	logger.silly("Finished setting configuration variables.");
 
 	// Execute the callback function
 	if (callback !== undefined)
@@ -152,12 +173,14 @@ function RequestUrl(test, callback) {
 
 	var t0 = now();
 
-	console.log(`Requesting ${test.url} for test ${test.name}...`);
+	logger.debug(`[${test.idx}] Requesting ${test.url}`);
 
 	// Switch proto to https if appropriate
 	if (test.url.startsWith("https://")) proto = https;
 
 	proto.get(test.url, (res) => {
+		logger.debug(`[${test.idx}] Response received with status code ${res.statusCode}`);
+
 		// Store the response code
 		response.responseCode = res.statusCode;
 
@@ -168,11 +191,37 @@ function RequestUrl(test, callback) {
 			response.responseData = data;
 			response.responseTime = (now() - t0).toFixed(0);
 
+			logger.debug(`[${test.idx}] Response data received totaling ${response.responseData.length} bytes`);
+
 			// Execute the callback
 			callback(test, response);
 		});
+		// As far as I can tell from the documentation this _should_ catch errors making the request, but doesn't...
+		res.on("error", (e) => {
+			logger.warn(`[${test.idx}] Error requesting ${test.url}:`, e);
+		});
 	});
 }
+
+// Initialize the logger
+logger = new winston.Logger({
+	level: "debug",
+	transports: [
+		new (winston.transports.Console)({
+			timestamp: function() {
+				return dateFormat(Date.now(), "HH:MM:ss");
+			},
+			formatter: function(options) {
+				// Return string will be passed to logger.
+				return options.timestamp() +' '+ options.level.toUpperCase() +' '+ (options.message ? options.message : '') +
+				(options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
+			}
+		})
+	]
+});
+
+// Log
+logger.info("Logger initialized");
 
 // Parse command-line arguments
 ParseCommandLine(process.argv);
@@ -184,15 +233,14 @@ configData = LoadConfigurationData(configFilename);
 if (ValidateConfigurationData(configData))
 	// Load the configuration
 	config = SetConfiguration(configData, () => {
-			console.log(`There are ${tests.length} tests.`);
-
 			// Loop over each test, scheduling it to run on its polling interval
 			for(i = 0;i<tests.length;i++) {
 				var test = tests[i];
 
 				// Schedule each test to run on its pollingInterval
 				setInterval(test.ExecuteTest.bind(test), test.pollingInterval);
-				//setInterval(() => { ExecuteTest(tests[i]) }, tests[i].pollingInterval);
+
+				logger.debug(`Test ${test.friendlyName} scheduled with an interval of ${test.pollingInterval / 1000} seconds.`);
 
 				// Mnaually fire each test to run immediately
 				test.ExecuteTest();
@@ -200,7 +248,8 @@ if (ValidateConfigurationData(configData))
 	});
 
 function ProcessTestResponse(test, response) {
-	console.log(`Request for test ${test.name} completed in ${response.responseTime}ms, returned ${response.responseData.length} bytes of data.`);
+	logger.debug(`[${test.idx}] Processing response of test ${test.friendlyName} with ${response.responseData.length} bytes of data and a ${response.responseCode} status code.`);
+	logger.debug(`[${test.idx}] Testing ${test.successCondition.length} conditions on the response`);
 
 	// Execute the specified tests on the response data
 	var responseTests = [];
@@ -214,28 +263,19 @@ function ProcessTestResponse(test, response) {
 
 		// Execute the test
 		if (condition.type == "responseCode")
-			testResult = testFunctions.responseCode(condition, response);
+			testResult = testFunctions.responseCode(test.idx, condition, response);
 		else if (condition.type == "responseSize")
-			testResult = testFunctions.responseSize(condition, response);
+			testResult = testFunctions.responseSize(test.idx, condition, response);
+		else if (condition.type == "contentMatch")
+			testResult = testFunctions.contentMatch(test.idx, condition, response);
 
 		// Check the result; if it's false, set overallRestResult to false because a failure of any condition is a failure of the entire test
 		if (!testResult)
 			overallTestResult = false;
 	});
 
-if (overallTestResult)
-	console.log("Test " + test.friendlyName + " completed with result " + overallTestResult.toString().green);
-else
-	console.log("Test " + test.friendlyName + " completed with result " + overallTestResult.toString().red);
-}
-
-function logResult(consoleData, fileData) {
-	if (fileData === undefined)
-		fileData = consoleData;
-
-	// Log to console
-	console.log(`[${dateFormat(new Date(), "HH:MM:ss")}]: ${consoleData}`);
-
-	// Log to file
-	fs.appendFileSync("./log.txt", `[${dateFormat(new Date(), "HH:MM:ss")}]: ${fileData}\n`);
+	if (overallTestResult)
+		logger.info(`Test ${test.friendlyName} completed with overall result of ${overallTestResult}`);
+	else
+		logger.warn(`Test ${test.friendlyName} completed with overall result of ${overallTestResult}`);
 }

--- a/config.json
+++ b/config.json
@@ -16,6 +16,14 @@
 				"type": "responseSize",
 				"minimum": 98000,
 				"maximum": 108000
+			},
+			{
+				"type": "contentMatch",
+				"matches": [
+					"What's Happening",
+					"Coming Up",
+					"Community Needs Assessment"
+				]
 			}
 		]
 	},
@@ -107,6 +115,7 @@
 			{
 				"type": "contentMatch",
 				"matches": [
+					"foundry"
 				]
 			}
 		]

--- a/config.json
+++ b/config.json
@@ -2,6 +2,14 @@
 	"version": 1,
 	"warnResponseTime": 600,
 	"slowResponseTime": 1000,
+	"logging": {
+		"enabled": true,
+		"consoleLogging": true,
+		"consoleLoggingLevel": "info",
+		"fileLogging": true,
+		"fileLoggingLevel": "silly",
+		"fileLoggingFile": "logfile.txt"
+	},
 	"tests" : [{
 		"name": "homepageTest",
 		"friendlyName": "City Homepage Test",

--- a/configSchema.json
+++ b/configSchema.json
@@ -2,6 +2,27 @@
 	"type": "object",
 	"properties": {
 		"version" : { "type": "number" },
+		"warnResponseTime": { "type": "number", "minimum": 0 },
+		"slowResponseTime": { "type": "number", "minimum": 0 },
+		"logging" : {
+			"type": "object",
+			"properties": {
+				"enabled": { "type": "boolean" },
+				"consoleLogging": { "type": "boolean" },
+				"consoleLoggingLevel": {
+					"type": {
+						"enum": ["error", "warn", "info", "verbose", "debug", "silly" ]
+					}
+				},
+				"fileLogging": { "type": "boolean" },
+				"fileLoggingLevel": {
+					"type": {
+						"enum": ["error", "warn", "info", "verbose", "debug", "silly" ]
+					}
+				},
+				"fileLoggingFile": { "type": "string" }
+			}
+		},
 		"tests": {
 			"type": "array",
 			"items": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "colors": "^1.1.2",
     "dateformat": "^2.0.0",
     "jsonschema": "^1.1.1",
-    "performance-now": "^2.1.0"
+    "performance-now": "^2.1.0",
+    "winston": "^2.3.1"
   }
 }

--- a/tests.js
+++ b/tests.js
@@ -1,44 +1,68 @@
 var tests = {
-	responseCode: function(condition, response) {
+	responseCode: function(idx, condition, response) {
 		if (condition.hasOwnProperty("exact"))
 		{
-			console.log(`Executing responseCode test for exact code ${condition.exact} with input code of ${response.responseCode}`);
-			return response.responseCode == condition.exact;
+			var result = response.responseCode == condition.exact;
+			logger.debug(`[${idx}] responseCode test for exact code ${condition.exact} ${((result) ? "passed" : "failed")} with input code of ${response.responseCode}`);
+
+			return result;
 		}
 		else if (condition.hasOwnProperty("series"))
 		{
-			console.log(`Executing responseCode test for series ${condition.series} with input code of ${response.series}`);
-			return response.responseCode.substring(0,1) == condition.series.substring(0,1);
+			var result = response.responseCode.toString().substring(0,1) == condition.series.substring(0,1);
+			logger.debug(`[${idx}] responseCode test for series ${condition.series} ${((result) ? "passed" : "failed")} with input code of ${response.responseCode}`);
+
+			return result;
 		}
 	},
-	notResponseCode: function(condition, response) {
+	notResponseCode: function(idx, condition, response) {
 		if (condition.hasOwnProperty("exact"))
 		{
-			console.log(`Executing notResponseCode test for exact code ${condition.exact} with input code of ${response.responseCode}`);
+			logger.debug(`[${idx}] Executing notResponseCode test for exact code ${condition.exact} with input code of ${response.responseCode}`);
 			return response.responseCode != condition.exact;
 		}
 		else if (condition.hasOwnProperty("series"))
 		{
-			console.log(`Executing notResponseCode test for series ${condition.series} with input code of ${response.series}`);
+			logger.debug(`[${idx}] Executing notResponseCode test for series ${condition.series} with input code of ${response.series}`);
 			return response.resposnecode.substring(0,1) != condition.series.substring(0,1);
 		}
 	},
-	responseSize: function(condition, response) {
+	responseSize: function(idx, condition, response) {
 		if (condition.minimum !== 0 && condition.minimum !== undefined && condition.maximum !== 0 && condition.maximum !== undefined)
 		{
-			console.log(`Executing responseSize test with minimum of ${condition.minimum} and maximum of ${condition.maximum} on response size of ${response.responseData.length}`);
+			logger.debug(`[${idx}] Executing responseSize test with minimum of ${condition.minimum} and maximum of ${condition.maximum} on response size of ${response.responseData.length}`);
 			return response.responseData.length > condition.minimum && response.responseData.length < condition.maximum;
 		}
 		else if (condition.minimum !== 0 && condition.minimum !== undefined)
 		{
-			console.log(`Executing responseSize test with minimum of ${condition.minimum} and no maximum on response size of ${response.responseData.length}`);
+			logger.debug(`[${idx}] Executing responseSize test with minimum of ${condition.minimum} and no maximum on response size of ${response.responseData.length}`);
 			return response.responseData.length > condition.minimum;
 		}
 		else if (condition.maximum !== 0 && condition.maximum !== undefined)
 		{
-			console.log(`Executing responseSize test with no minimum and maximum of ${condition.maximum} on response size of ${response.responseData.length}`);
+			logger.debug(`[${idx}] Executing responseSize test with no minimum and maximum of ${condition.maximum} on response size of ${response.responseData.length}`);
 			return response.responseData.length < condition.maximum;
 		}
+	},
+	contentMatch: function(idx, condition, response) {
+		var result = true;
+
+		logger.debug(`[${idx}] Executing contentMatch test against terms "${condition.matches}"`);
+
+		// Iterate over the strings to match for; if any fail, result will be set to false
+		condition.matches.forEach((match) => {
+			var loc = response.responseData.indexOf(match);
+
+			if (loc === -1)
+			{
+				result = false;
+				logger.debug(`[${idx}] contentMatch test failed against term "${match}": ${response.responseData.indexOf(match)}`);
+			}
+			else
+				logger.debug(`[${idx}] contentMatch test passed against term "${match}", found at location ${loc}`);
+		});
+
+		return result;
 	}
 };
 


### PR DESCRIPTION
Logging services are provided through Winston, and are configurable through the application's config.json file. Supported transports are console and file. There's probably a cleaner way to implement the (re)configuration of the logger, but if it ain't broke don't fix it (right now), right?